### PR TITLE
[Feature] Add always-export-in-smart-contract rule

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ const snarkyJSRules: string[] = [
   'no-json-functions-in-circuit',
   'no-random-in-circuit',
   'no-constructor-in-smart-contract',
+  'always-export-in-smart-contract',
 ]
 
 const snarkyJSRuleModules: { [key: string]: any } = {}

--- a/src/rules/always-export-in-smart-contract.ts
+++ b/src/rules/always-export-in-smart-contract.ts
@@ -1,0 +1,36 @@
+import type { TSESLint, TSESTree } from '@typescript-eslint/experimental-utils'
+import { SMART_CONTRACT_DEFINITION } from '../utils/selectors'
+import { hasExportNamedDeclaration } from '../utils/node-utils'
+
+const rule: TSESLint.RuleModule<string, string[]> = {
+  meta: {
+    messages: {
+      alwaysExportSmartContract:
+        'All Smart Contracts should be exported using a named export. Please add `export` to your Smart Contract class',
+    },
+    schema: [],
+    type: 'problem',
+    docs: {
+      description:
+        'All Smart Contracts should be exported using a named export. Please add `export` to your Smart Contract class',
+      recommended: 'error',
+    },
+  },
+
+  create(context) {
+    return {
+      [`${SMART_CONTRACT_DEFINITION}`]: function (
+        classNode: TSESTree.ClassDeclaration
+      ) {
+        if (classNode.parent && !hasExportNamedDeclaration(classNode.parent)) {
+          context.report({
+            messageId: `alwaysExportSmartContract`,
+            loc: classNode.loc,
+          })
+        }
+      },
+    }
+  },
+}
+
+export = rule

--- a/src/utils/node-utils.ts
+++ b/src/utils/node-utils.ts
@@ -97,3 +97,7 @@ export function isTSArrayType(
 ): node is TSESTree.TSArrayType {
   return node !== undefined && node.type === 'TSArrayType'
 }
+
+export function hasExportNamedDeclaration(node: TSESTree.Node) {
+  return node !== undefined && node.type === 'ExportNamedDeclaration'
+}

--- a/tests/rules/always-export-in-smart-contract.test.ts
+++ b/tests/rules/always-export-in-smart-contract.test.ts
@@ -1,0 +1,48 @@
+import { ruleTester } from '../rule-tester'
+import rule from '../../src/rules/always-export-in-smart-contract'
+
+const message = 'alwaysExportSmartContract'
+
+ruleTester.run('always-export-in-smart-contract', rule, {
+  valid: [
+    {
+      code: `export class Foo extends SmartContract {}`,
+    },
+    {
+      code: `
+      export class Foo extends SmartContract {}
+      export class Bar extends SmartContract {}
+      `,
+    },
+    {
+      code: `
+      class Foo {}
+      class Bar {}
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `class Foo extends SmartContract {}`,
+      errors: [{ messageId: message }],
+    },
+    {
+      code: `export default class Foo extends SmartContract {}`,
+      errors: [{ messageId: message }],
+    },
+    {
+      code: `
+      export class Bar extends SmartContract {}
+      class Foo extends SmartContract {}
+      `,
+      errors: [{ messageId: message }],
+    },
+    {
+      code: `
+      export class Bar extends SmartContract {}
+      export default class Foo extends SmartContract {}
+      `,
+      errors: [{ messageId: message }],
+    },
+  ],
+})


### PR DESCRIPTION
**Description**
Add a rule that enforced using a named export whenever a class extends 'SmartContract'. This rule is enforced because using a named export for smart contracts is considered idiomatic for SnarkyJS. This idea originally originated from the zkapp-cli needing to import the users code and using named exports for that is the most reliable way to do so.

**Tested By**
Adding the respective unit tests